### PR TITLE
Added printed parts info to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,81 @@
-# MPX-VORON-TRIDENT-CBT
- 
+# Print Guide
+
+## Electronics_Bay
+
+Completely skip official `electronics_bay` folder.
+
+Print our printed parts name started with `Elec`
+
+You totally need these:
+
+2pcs `Elec_Din_Clip_x2.stl`
+
+4pcs `Elec_LRS_200_Mount_x4.STL`
+
+1pcs `Elec_M8P_Mount.STL`
+
+
+## Exhaust Filter
+
+We use nevermore in out kit, so you can completely skip official `exhaust filter` folder.
+
+Print these parts to seal the back panel:
+
+1pcs `Exhaust_cover.stl`
+
+1pcs `Exhaust_filter_grill.stl`
+
+> This mod comes from Fictio's [Exhaust_cover](Fiction/https://github.com/VoronDesign/VoronUsers/tree/master/printer_mods/Fiction/Exhaust_cover)
+
+
+## Gantry
+
+Skip these parts:
+
+<!-- TODO: need to be defined -->
+
+
+## Panel_Mounting
+
+Use `deck_support_3mm_x8.stl` and skip the 4mm one.
+
+
+## Skirts
+
+Use `power_inlet_IECGS_1.2mm.stl` and skip other `power_inlet_*`
+
+
+## Z Endstop
+
+Skip this folder, we use VORON Tap as z endstop. 
+
+
+## VORON Tap
+
+Print these parts and follow offical tap guide.
+
+https://github.com/VoronDesign/Voron-Tap/tree/main/STLs
+
+Print `Tap_Upper_PCB_r2.stl` and skip other `Tap_Upper_*`
+
+
+## Stealthburner
+
+Skip `X_Carriage` folder
+
+Skip `Clockwork2/cable_door.stl` and print `cable_door_for_pcb.stl`
+
+Skip `Clockwork2/chain_*`
+
+Print these from our github:
+
+Print `Toolhead_Cable_Bridge.STL`
+
+Print `Toolhead_Can_Cable_Fix.stl`
+
+
+## Disco Strick 
+
+Print 2pcs `LED_2020_x2.stl`
+
+> This mod comes from [Daylight](https://github.com/VoronDesign/Voron-Hardware/tree/master/Daylight/Disco_on_a_stick_XXL)


### PR DESCRIPTION
I saw that the readme for the printed parts of the MPX trident wasn't there yet like it is for the 2.4 MPX version.

I made an initial setup for the readme with the stuff I could deduce from the 2.4 readme.